### PR TITLE
Release 0.0.2 with Diary alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ uv add tomldiary pydantic-ai
 ```python
 from pydantic import BaseModel
 from typing import Dict
-from tomldiary import TOMLDiary, PreferenceItem
+from tomldiary import Diary, PreferenceItem
 from tomldiary.backends import LocalBackend
 
 # Be as specific as possible in your preference schema, it passed to the system prompt of the agent extracting the data!
@@ -44,7 +44,7 @@ class MyPrefTable(BaseModel):
     biography: Dict[str, PreferenceItem] = {}
 
 
-diary = TOMLDiary(
+diary = Diary(
     backend=LocalBackend(path="./memories"),
     pref_table_cls=MyPrefTable,
     max_prefs_per_category=100,
@@ -124,7 +124,7 @@ backend = LocalBackend(Path("./memories"))
 # S3 backend (implement S3Backend)
 # backend = S3Backend(bucket="my-memories")
 
-# Redis backend (implement RedisBackend)  
+# Redis backend (implement RedisBackend)
 # backend = RedisBackend(host="localhost")
 ```
 
@@ -143,7 +143,7 @@ writer = MemoryWriter(
 
 ## API Reference
 
-### TOMLDiary
+### Diary
 
 Main class for memory operations:
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -47,7 +47,7 @@ class S3Backend:
         self.bucket = bucket
         self.prefix = prefix
         self.session = aioboto3.Session()
-    
+
     async def load(self, user_id: str, kind: str) -> Optional[str]:
         async with self.session.client('s3') as s3:
             key = f"{self.prefix}/{user_id}_{kind}.toml"
@@ -57,7 +57,7 @@ class S3Backend:
                 return content.decode('utf-8')
             except s3.exceptions.NoSuchKey:
                 return None
-    
+
     async def save(self, user_id: str, kind: str, content: str):
         async with self.session.client('s3') as s3:
             key = f"{self.prefix}/{user_id}_{kind}.toml"
@@ -79,18 +79,18 @@ class RedisBackend:
     def __init__(self, redis_url: str = "redis://localhost"):
         self.redis_url = redis_url
         self.redis = None
-    
+
     async def _get_redis(self):
         if not self.redis:
             self.redis = await aioredis.from_url(self.redis_url)
         return self.redis
-    
+
     async def load(self, user_id: str, kind: str) -> Optional[str]:
         redis = await self._get_redis()
         key = f"memory:{user_id}:{kind}"
         value = await redis.get(key)
         return value.decode('utf-8') if value else None
-    
+
     async def save(self, user_id: str, kind: str, content: str):
         redis = await self._get_redis()
         key = f"memory:{user_id}:{kind}"
@@ -116,7 +116,7 @@ Be conservative about what you store.
 """)
 
 # Use your custom agent
-diary = TOMLDiary(
+diary = Diary(
     backend=backend,
     pref_table_cls=MyPrefTable,
     agent=(agent, allowed_categories)
@@ -149,7 +149,7 @@ async def batch_process(writer, conversations):
     for user_id, session_id, user_msg, bot_msg in conversations:
         task = writer.submit(user_id, session_id, user_msg, bot_msg)
         tasks.append(task)
-    
+
     # Submit all at once
     await asyncio.gather(*tasks)
 ```
@@ -161,7 +161,7 @@ async def batch_process(writer, conversations):
 The diary automatically enforces limits:
 
 ```python
-diary = TOMLDiary(
+diary = Diary(
     backend=backend,
     pref_table_cls=MyPrefTable,
     max_prefs_per_category=50,  # Keep only top 50 per category
@@ -177,20 +177,20 @@ Implement custom cleanup logic:
 async def cleanup_old_memories(diary, user_id, days=30):
     # Load conversations
     convs_data = await diary._load_convs(user_id)
-    
+
     # Filter old conversations
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     filtered = {}
-    
+
     for session_id, conv in convs_data.items():
         if session_id == "_meta":
             filtered[session_id] = conv
             continue
-            
+
         created = datetime.fromisoformat(conv.get("_created", ""))
         if created > cutoff:
             filtered[session_id] = conv
-    
+
     # Save filtered data
     await diary._save_convs(user_id, filtered)
 ```
@@ -207,10 +207,10 @@ class RobustMemoryWriter(MemoryWriter):
         except Exception as e:
             # Log error
             print(f"Failed to process memory: {e}")
-            
+
             # Send to dead letter queue
             await self.dead_letter_queue.put(item)
-            
+
             # Alert monitoring
             await self.alert_monitor(item, e)
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,12 +2,12 @@
 
 ## Core Classes
 
-### TOMLDiary
+### Diary
 
 The main class for managing user memories.
 
 ```python
-class TOMLDiary:
+class Diary:
     def __init__(
         self,
         backend: Backend,
@@ -48,7 +48,7 @@ Background queue system for non-blocking memory updates.
 class MemoryWriter:
     def __init__(
         self,
-        diary: TOMLDiary,
+        diary: Diary,
         workers: int = 3,
         qsize: int = 100,
         retry_limit: int = 3,
@@ -58,7 +58,7 @@ class MemoryWriter:
 
 #### Parameters
 
-- `diary`: TOMLDiary instance to write to
+- `diary`: Diary instance to write to
 - `workers`: Number of background worker tasks
 - `qsize`: Maximum queue size
 - `retry_limit`: Maximum retries on failure

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ uv sync
 
 tomldiary provides three main components:
 
-1. **TOMLDiary**: The core class that manages memory storage and retrieval, it can have many "backends" to preserve the information
+1. **Diary**: The core class that manages memory storage and retrieval, it can have many "backends" to preserve the information
 2. **MemoryWriter**: A background queue system for non-blocking memory updates
 3. **Preference Tables**: Pydantic models that define memory categories (eg, "about", "likes", "dislike")
 
@@ -28,8 +28,8 @@ from pathlib import Path
 from pydantic import BaseModel
 from typing import Dict
 from tomldiary import (
-    TOMLDiary, 
-    MemoryWriter, 
+    Diary,
+    MemoryWriter,
     PreferenceItem,
     shutdown_all_background_tasks
 )
@@ -46,14 +46,14 @@ class SimplePrefTable(BaseModel):
 
 async def main():
     # Step 2: Create the diary
-    diary = TOMLDiary(
+    diary = Diary(
         backend=LocalBackend(Path("./my_memories")),
         pref_table_cls=SimplePrefTable
     )
-    
+
     # Step 3: Create the writer
     writer = MemoryWriter(diary)
-    
+
     # Step 4: Process some conversations, requires LLM call
     await writer.submit(
         user_id="user123",
@@ -61,15 +61,15 @@ async def main():
         user_message="I love chocolate ice cream!",
         assistant_response="I'll remember you love chocolate ice cream."
     )
-    
+
     # Wait a bit for processing
     await asyncio.sleep(1)
-    
+
     # Step 5: Read the memories
     prefs = await diary.preferences("user123")
     print("User preferences:")
     print(prefs)
-    
+
     # Step 6: Clean up
     await writer.close()
     await shutdown_all_background_tasks()

--- a/examples/example_cooking_show.py
+++ b/examples/example_cooking_show.py
@@ -7,7 +7,7 @@ Celebrity chefs discuss their culinary preferences with an AI host.
 import asyncio
 from pathlib import Path
 from pydantic_ai import Agent, RunContext
-from tomldiary import TOMLDiary, MemoryWriter, shutdown_all_background_tasks
+from tomldiary import Diary, MemoryWriter, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 from culinary_prefs import CulinaryPrefTable
 import tomllib
@@ -16,7 +16,7 @@ from typing import Dict, Any
 
 # Define the deps type for our cooking show context
 class CookingShowContext:
-    def __init__(self, chef_name: str, episode: str, diary: TOMLDiary, writer: MemoryWriter):
+    def __init__(self, chef_name: str, episode: str, diary: Diary, writer: MemoryWriter):
         self.chef_name = chef_name
         self.episode = episode
         self.diary = diary
@@ -56,12 +56,12 @@ async def save_memory(ctx: RunContext[CookingShowContext], user_msg: str, assist
     return "Memory saved"
 
 
-@chef_agent.tool  
+@chef_agent.tool
 async def record_preference(ctx: RunContext[CookingShowContext], category: str, item: str, text: str, contexts: list[str]) -> str:
     """Record a preference in the chef's profile"""
     prefs = ctx.deps.prefs.setdefault("preferences", {})
     cat_prefs = prefs.setdefault(category, {})
-    
+
     cat_prefs[item] = {
         "text": text,
         "contexts": contexts,
@@ -69,41 +69,41 @@ async def record_preference(ctx: RunContext[CookingShowContext], category: str, 
         "_created": "2024-01-01T00:00:00Z",
         "_updated": "2024-01-01T00:00:00Z"
     }
-    
+
     return f"Recorded {category}: {item}"
 
 
-async def chef_interview(chef_name: str, chef_personality: str, episodes: list[tuple[str, str]], diary: TOMLDiary, writer: MemoryWriter):
+async def chef_interview(chef_name: str, chef_personality: str, episodes: list[tuple[str, str]], diary: Diary, writer: MemoryWriter):
     """Conduct an interview with a celebrity chef"""
-    
+
     for episode, topic in episodes:
         print(f"\n📺 {chef_name} - Episode: {episode}")
         print("-" * 40)
-        
+
         context = CookingShowContext(chef_name, episode, diary, writer)
-        
+
         # Customize chef's personality
         chef_with_personality = chef_agent.override(
             system_prompt=chef_agent._system_prompt + f"\n\nYour personality: {chef_personality}"
         )
-        
+
         # Host introduces the topic
         host_intro = await host_agent.run(
             f"Welcome chef! Today let's talk about {topic}. What are your thoughts?",
             deps=context
         )
         print(f"🎤 Host: {host_intro.data}")
-        
+
         # Chef responds
         chef_response = await chef_with_personality.run(
             host_intro.data,
             deps=context
         )
         print(f"👨‍🍳 {chef_name}: {chef_response.data}")
-        
+
         # Save the initial exchange
         await context.writer.submit(chef_name, episode, host_intro.data, chef_response.data)
-        
+
         # Continue conversation with follow-up
         host_followup = await host_agent.run(
             f"That's fascinating! Can you tell me more about your preferences regarding {topic}?",
@@ -111,14 +111,14 @@ async def chef_interview(chef_name: str, chef_personality: str, episodes: list[t
             message_history=host_intro.new_messages()
         )
         print(f"🎤 Host: {host_followup.data}")
-        
+
         chef_detail = await chef_with_personality.run(
             host_followup.data,
             deps=context,
             message_history=chef_response.new_messages()
         )
         print(f"👨‍🍳 {chef_name}: {chef_detail.data}")
-        
+
         # Save the follow-up
         await context.writer.submit(chef_name, episode, host_followup.data, chef_detail.data)
 
@@ -127,27 +127,27 @@ async def cooking_show_demo():
     """Run the AI-powered cooking show memory demo."""
     print("🍳 Welcome to the AI Cooking Show Memory System!")
     print("=" * 50)
-    
+
     # Setup
     backend = LocalBackend(Path("memory_cooking_show"))
-    
+
     # Create diary with the original CulinaryAgent for memory extraction
-    from tomldiary import TOMLDiary
-    
+    from tomldiary import Diary
+
     class CulinaryAgent:
         """Agent that extracts cooking preferences from conversations."""
-        
+
         async def run(self, message: str, deps=None):
             if not deps:
                 return
-            
+
             msg_lower = message.lower()
             prefs = deps.prefs.setdefault("preferences", {})
-            
+
             # Extract favorite foods
             if any(word in msg_lower for word in ["love", "favorite", "enjoy", "best", "prefer", "fantastic", "amazing"]):
                 favorite_foods = prefs.setdefault("favorite_foods", {})
-                
+
                 if "pasta" in msg_lower:
                     favorite_foods["pasta"] = {
                         "text": "enjoys pasta dishes",
@@ -156,7 +156,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "sushi" in msg_lower:
                     favorite_foods["sushi"] = {
                         "text": "loves sushi",
@@ -165,7 +165,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "chocolate" in msg_lower:
                     favorite_foods["chocolate"] = {
                         "text": "chocolate lover",
@@ -174,11 +174,11 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-            
+
             # Extract cooking techniques
             if any(word in msg_lower for word in ["technique", "method", "style", "way"]):
                 techniques = prefs.setdefault("cooking_techniques", {})
-                
+
                 if "grill" in msg_lower or "bbq" in msg_lower:
                     techniques["grilling"] = {
                         "text": "specializes in grilling and BBQ",
@@ -187,7 +187,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "french" in msg_lower and ("technique" in msg_lower or "method" in msg_lower):
                     techniques["french_cooking"] = {
                         "text": "trained in French cooking techniques",
@@ -196,11 +196,11 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-            
+
             # Extract dislikes
             if any(word in msg_lower for word in ["hate", "dislike", "avoid", "never", "can't stand", "terrible"]):
                 dislikes = prefs.setdefault("dislike", {})
-                
+
                 if "spicy" in msg_lower:
                     dislikes["spicy_food"] = {
                         "text": "avoids spicy food",
@@ -209,7 +209,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "overcooked" in msg_lower or "overcook" in msg_lower:
                     dislikes["overcooked_food"] = {
                         "text": "hates overcooked food",
@@ -218,11 +218,11 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-            
+
             # Extract dietary restrictions
             if any(word in msg_lower for word in ["allergic", "allergy", "vegetarian", "vegan", "gluten", "lactose"]):
                 restrictions = prefs.setdefault("dietary_restrictions", {})
-                
+
                 if "nuts" in msg_lower or "peanut" in msg_lower:
                     restrictions["nuts"] = {
                         "text": "nut allergy",
@@ -231,7 +231,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "shellfish" in msg_lower:
                     restrictions["shellfish"] = {
                         "text": "shellfish allergy",
@@ -240,11 +240,11 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-            
+
             # Extract cooking habits
             if any(word in msg_lower for word in ["always", "every", "daily", "regularly", "routine", "habit"]):
                 habits = prefs.setdefault("cooking_habits", {})
-                
+
                 if "breakfast" in msg_lower:
                     habits["breakfast_cooking"] = {
                         "text": "cooks breakfast regularly",
@@ -253,7 +253,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "taste" in msg_lower and "while" in msg_lower:
                     habits["taste_while_cooking"] = {
                         "text": "always tastes food while cooking",
@@ -262,7 +262,7 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-                
+
                 if "fresh" in msg_lower and ("pasta" in msg_lower or "ingredient" in msg_lower):
                     habits["fresh_ingredients"] = {
                         "text": "uses fresh ingredients daily",
@@ -271,19 +271,19 @@ async def cooking_show_demo():
                         "_created": "2024-01-01T00:00:00Z",
                         "_updated": "2024-01-01T00:00:00Z"
                     }
-    
+
     agent = CulinaryAgent()
-    
-    diary = TOMLDiary(
+
+    diary = Diary(
         backend=backend,
         pref_table_cls=CulinaryPrefTable,
         agent=(agent, ["favorite_foods", "cooking_techniques", "flavor_preferences", "dislikes", "dietary_restrictions", "cooking_habits", "ingredient_preferences"]),
         max_prefs_per_category=10,
         max_conversations=5
     )
-    
+
     writer = MemoryWriter(diary, workers=4, qsize=20)
-    
+
     # Chef personalities and interview topics
     chefs = [
         ("chef_gordon", "A passionate British chef known for high standards and fiery temperament. Loves perfection.", [
@@ -299,74 +299,74 @@ async def cooking_show_demo():
             ("ingredient_focus", "working with fresh ingredients")
         ])
     ]
-    
+
     # Conduct interviews
     print("\n🎬 Starting celebrity chef interviews...\n")
-    
+
     for chef_name, personality, episodes in chefs:
         await chef_interview(chef_name, personality, episodes, diary, writer)
         await asyncio.sleep(0.5)  # Brief pause between chefs
-    
+
     # Let processing complete
     await asyncio.sleep(1)
-    
+
     # Display the memories
     print("\n\n📚 Chef Profiles & Memories:")
     print("=" * 50)
-    
+
     for chef_name, _, _ in chefs:
         print(f"\n👨‍🍳 {chef_name.upper()}")
         print("-" * 30)
-        
+
         # Show preferences
         prefs_toml = await diary.preferences(chef_name)
         if prefs_toml:
             prefs_data = tomllib.loads(prefs_toml)
             preferences = prefs_data.get("preferences", {})
-            
+
             if "favorite_foods" in preferences:
                 print("  🍽️  Favorite Foods:")
                 for item, details in preferences["favorite_foods"].items():
                     print(f"    - {item}: {details['text']} (mentioned {details.get('_count', 1)}x)")
-            
+
             if "cooking_techniques" in preferences:
                 print("  👨‍🍳 Cooking Techniques:")
                 for item, details in preferences["cooking_techniques"].items():
                     print(f"    - {item}: {details['text']}")
-            
+
             if "dislikes" in preferences:
                 print("  👎 Dislikes:")
                 for item, details in preferences["dislikes"].items():
                     print(f"    - {item}: {details['text']}")
-            
+
             if "dietary_restrictions" in preferences:
                 print("  ⚠️  Dietary Restrictions:")
                 for item, details in preferences["dietary_restrictions"].items():
                     print(f"    - {item}: {details['text']}")
-            
+
             if "cooking_habits" in preferences:
                 print("  🔄 Cooking Habits:")
                 for item, details in preferences["cooking_habits"].items():
                     print(f"    - {item}: {details['text']}")
-        
+
         # Show episodes
         conversations = await diary.last_conversations(chef_name, n=5)
         if conversations:
             print(f"  📺 Recent Episodes ({len(conversations)}):")
             for session_id, conv in conversations.items():
                 print(f"    - {session_id}: {conv['_turns']} segments recorded")
-    
+
     # Show sample TOML
     print("\n📄 Sample TOML file (chef_gordon preferences):")
     print("-" * 50)
     gordon_prefs = await diary.preferences("chef_gordon")
     if gordon_prefs:
         print(gordon_prefs[:500] + "..." if len(gordon_prefs) > 500 else gordon_prefs)
-    
+
     # Cleanup
     await writer.close()
     await shutdown_all_background_tasks()
-    
+
     print("\n✨ Cooking show memories saved successfully!")
     print(f"📁 Check the 'memory_cooking_show' directory for TOML files")
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -10,8 +10,7 @@ import asyncio
 from pathlib import Path
 
 from pydantic import BaseModel, Field
-
-from tomldiary import MemoryWriter, TOMLDiary, shutdown_all_background_tasks
+from tomldiary import Diary, MemoryWriter, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 from tomldiary.models import PreferenceItem
 
@@ -107,7 +106,7 @@ async def simple_demo():
 
     # 2. Create diary with simple schema
     print("2️⃣ Creating memory diary...")
-    diary = TOMLDiary(
+    diary = Diary(
         backend=backend,
         pref_table_cls=SimplePrefTable,
         agent=(agent, ["like", "dislike", "about"]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tomldiary"
-version = "0.0.1"
+version = "0.0.2"
 description = "A lightweight TOML-based memory system for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/tomldiary/__init__.py
+++ b/src/tomldiary/__init__.py
@@ -7,7 +7,11 @@ from .extractor_factory import build_extractor
 from .models import ConversationItem, MemoryDeps, MetaInfo, PreferenceItem
 from .writer import MemoryWriter, shutdown_all_background_tasks
 
+# Easier to type alias
+Diary = TOMLDiary
+
 __all__ = [
+    "Diary",
     "TOMLDiary",
     "PreferenceItem",
     "ConversationItem",

--- a/tests/test_diary.py
+++ b/tests/test_diary.py
@@ -7,9 +7,8 @@ import tomllib
 from pathlib import Path
 
 import pytest
-
+from tomldiary import Diary
 from tomldiary.backends.local import LocalBackend
-from tomldiary.diary import TOMLDiary
 from tomldiary.models import MemoryDeps
 
 from .test_user_pref_table import MyPrefTable
@@ -36,8 +35,8 @@ class MockAgent:
             }
 
 
-class TestTOMLDiary:
-    """Test TOMLDiary functionality."""
+class TestDiary:
+    """Test Diary functionality."""
 
     @pytest.fixture
     def temp_dir(self):
@@ -59,8 +58,8 @@ class TestTOMLDiary:
 
     @pytest.fixture
     def diary(self, backend, mock_agent):
-        """Create TOMLDiary with mock agent."""
-        return TOMLDiary(
+        """Create Diary with mock agent."""
+        return Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(mock_agent, ["like", "dislike", "allergy", "habit", "about"]),
@@ -158,7 +157,7 @@ class TestTOMLDiary:
     async def test_preference_limits(self, diary, backend):
         """Test preference limit enforcement."""
         # Create diary with very low preference limit
-        diary_low_limit = TOMLDiary(
+        diary_low_limit = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(MockAgent(), ["like", "dislike", "allergy", "habit", "about"]),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,8 +7,7 @@ import tomllib
 from pathlib import Path
 
 import pytest
-
-from tomldiary import MemoryWriter, TOMLDiary, shutdown_all_background_tasks
+from tomldiary import Diary, MemoryWriter, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 
 from .test_user_pref_table import MyPrefTable
@@ -76,7 +75,7 @@ class TestIntegration:
         """Create complete diary system."""
         backend = LocalBackend(temp_dir)
         agent = MockExtractionAgent()
-        diary = TOMLDiary(
+        diary = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(agent, ["like", "dislike", "allergy", "habit", "about"]),
@@ -192,7 +191,7 @@ class TestIntegration:
         agent = MockExtractionAgent()
 
         # Create diary with very low limits
-        diary = TOMLDiary(
+        diary = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(agent, ["like", "dislike", "allergy", "habit", "about"]),
@@ -230,7 +229,7 @@ class TestIntegration:
         await writer1.close()
 
         # Create new diary instance with same backend
-        diary2 = TOMLDiary(
+        diary2 = Diary(
             backend=diary1.backend,  # Same backend
             pref_table_cls=MyPrefTable,
             agent=(MockExtractionAgent(), ["like", "dislike", "allergy", "habit", "about"]),
@@ -331,7 +330,7 @@ class TestIntegration:
                 if self.call_count % 3 == 0:  # Fail every 3rd call
                     raise RuntimeError("Simulated agent failure")
 
-        diary = TOMLDiary(
+        diary = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(FlakyAgent(), ["like", "dislike", "allergy", "habit", "about"]),


### PR DESCRIPTION
## Summary
- bump version to 0.0.2
- expose `Diary` as convenient alias for `TOMLDiary`
- update documentation and examples to use `Diary`
- adjust tests to import `Diary`

## Testing
- `pre-commit run --files src/tomldiary/__init__.py pyproject.toml README.md docs/advanced-usage.md docs/api-reference.md docs/getting-started.md examples/simple_example.py examples/example_cooking_show.py tests/test_integration.py tests/test_diary.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688510a039f4832a85412733434b17e3