### PR TITLE
Rename TOMLDiary to Diary class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,32 +10,26 @@ git clone https://github.com/yourusername/tomldiary.git
 cd tomldiary
 ```
 
-2. Create a virtual environment:
+2. Install dependencies with uv:
 ```bash
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+uv sync --group dev
 ```
 
-3. Install in development mode:
+3. Install pre-commit hooks:
 ```bash
-pip install -e ".[dev]"
-```
-
-4. Install pre-commit hooks:
-```bash
-pre-commit install
+uv run pre-commit install
 ```
 
 ## Running Tests
 
 Run the test suite:
 ```bash
-pytest
+uv run pytest
 ```
 
 Run with coverage:
 ```bash
-pytest --cov=tomldiary --cov-report=html
+uv run pytest --cov=tomldiary --cov-report=html
 ```
 
 ## Code Style
@@ -44,13 +38,13 @@ We use `ruff` for linting and formatting. The pre-commit hooks will automaticall
 
 ```bash
 # Format code
-ruff format .
+uv run ruff format .
 
 # Check linting
-ruff check .
+uv run ruff check .
 
 # Fix auto-fixable issues
-ruff check --fix .
+uv run ruff check --fix .
 ```
 
 ## Making Changes

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ from tomldiary import Diary, PreferenceItem
 from tomldiary.backends import LocalBackend
 
 # Be as specific as possible in your preference schema, it passed to the system prompt of the agent extracting the data!
+# This of the fields as the "slots" to organize facts into and tell the agent what to remember.
 class MyPrefTable(BaseModel):
     """
     likes    : What the user enjoys
@@ -177,7 +178,7 @@ See the `examples/` directory for:
 
 ```bash
 # Install dev dependencies
-pip install -e ".[dev]"
+uv sync --group dev
 
 # Run tests
 pytest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ uv add tomldiary pydantic-ai
 ```python
 from pydantic import BaseModel
 from typing import Dict
-from tomldiary import TOMLDiary, PreferenceItem
+from tomldiary import Diary, PreferenceItem
 from tomldiary.backends import LocalBackend
 
 # Be as specific as possible in your preference schema, it passed to the system prompt of the agent extracting the data!
@@ -44,7 +44,7 @@ class MyPrefTable(BaseModel):
     biography: Dict[str, PreferenceItem] = {}
 
 
-diary = TOMLDiary(
+diary = Diary(
     backend=LocalBackend(path="./memories"),
     pref_table_cls=MyPrefTable,
     max_prefs_per_category=100,
@@ -143,7 +143,7 @@ writer = MemoryWriter(
 
 ## API Reference
 
-### TOMLDiary
+### Diary
 
 Main class for memory operations:
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -116,7 +116,7 @@ Be conservative about what you store.
 """)
 
 # Use your custom agent
-diary = TOMLDiary(
+diary = Diary(
     backend=backend,
     pref_table_cls=MyPrefTable,
     agent=(agent, allowed_categories)
@@ -161,7 +161,7 @@ async def batch_process(writer, conversations):
 The diary automatically enforces limits:
 
 ```python
-diary = TOMLDiary(
+diary = Diary(
     backend=backend,
     pref_table_cls=MyPrefTable,
     max_prefs_per_category=50,  # Keep only top 50 per category

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,12 +2,12 @@
 
 ## Core Classes
 
-### TOMLDiary
+### Diary
 
 The main class for managing user memories.
 
 ```python
-class TOMLDiary:
+class Diary:
     def __init__(
         self,
         backend: Backend,
@@ -48,7 +48,7 @@ Background queue system for non-blocking memory updates.
 class MemoryWriter:
     def __init__(
         self,
-        diary: TOMLDiary,
+        diary: Diary,
         workers: int = 3,
         qsize: int = 100,
         retry_limit: int = 3,
@@ -58,7 +58,7 @@ class MemoryWriter:
 
 #### Parameters
 
-- `diary`: TOMLDiary instance to write to
+- `diary`: Diary instance to write to
 - `workers`: Number of background worker tasks
 - `qsize`: Maximum queue size
 - `retry_limit`: Maximum retries on failure

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ uv sync
 
 tomldiary provides three main components:
 
-1. **TOMLDiary**: The core class that manages memory storage and retrieval, it can have many "backends" to preserve the information
+1. **Diary**: The core class that manages memory storage and retrieval, it can have many "backends" to preserve the information
 2. **MemoryWriter**: A background queue system for non-blocking memory updates
 3. **Preference Tables**: Pydantic models that define memory categories (eg, "about", "likes", "dislike")
 
@@ -28,7 +28,7 @@ from pathlib import Path
 from pydantic import BaseModel
 from typing import Dict
 from tomldiary import (
-    TOMLDiary, 
+    Diary,
     MemoryWriter, 
     PreferenceItem,
     shutdown_all_background_tasks
@@ -46,7 +46,7 @@ class SimplePrefTable(BaseModel):
 
 async def main():
     # Step 2: Create the diary
-    diary = TOMLDiary(
+    diary = Diary(
         backend=LocalBackend(Path("./my_memories")),
         pref_table_cls=SimplePrefTable
     )

--- a/examples/example_cooking_show.py
+++ b/examples/example_cooking_show.py
@@ -7,7 +7,7 @@ Celebrity chefs discuss their culinary preferences with an AI host.
 import asyncio
 from pathlib import Path
 from pydantic_ai import Agent, RunContext
-from tomldiary import TOMLDiary, MemoryWriter, shutdown_all_background_tasks
+from tomldiary import Diary, MemoryWriter, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 from culinary_prefs import CulinaryPrefTable
 import tomllib
@@ -16,7 +16,7 @@ from typing import Dict, Any
 
 # Define the deps type for our cooking show context
 class CookingShowContext:
-    def __init__(self, chef_name: str, episode: str, diary: TOMLDiary, writer: MemoryWriter):
+    def __init__(self, chef_name: str, episode: str, diary: Diary, writer: MemoryWriter):
         self.chef_name = chef_name
         self.episode = episode
         self.diary = diary
@@ -73,7 +73,7 @@ async def record_preference(ctx: RunContext[CookingShowContext], category: str, 
     return f"Recorded {category}: {item}"
 
 
-async def chef_interview(chef_name: str, chef_personality: str, episodes: list[tuple[str, str]], diary: TOMLDiary, writer: MemoryWriter):
+async def chef_interview(chef_name: str, chef_personality: str, episodes: list[tuple[str, str]], diary: Diary, writer: MemoryWriter):
     """Conduct an interview with a celebrity chef"""
     
     for episode, topic in episodes:
@@ -132,7 +132,7 @@ async def cooking_show_demo():
     backend = LocalBackend(Path("memory_cooking_show"))
     
     # Create diary with the original CulinaryAgent for memory extraction
-    from tomldiary import TOMLDiary
+    from tomldiary import Diary
     
     class CulinaryAgent:
         """Agent that extracts cooking preferences from conversations."""
@@ -274,7 +274,7 @@ async def cooking_show_demo():
     
     agent = CulinaryAgent()
     
-    diary = TOMLDiary(
+    diary = Diary(
         backend=backend,
         pref_table_cls=CulinaryPrefTable,
         agent=(agent, ["favorite_foods", "cooking_techniques", "flavor_preferences", "dislikes", "dietary_restrictions", "cooking_habits", "ingredient_preferences"]),

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -2,7 +2,7 @@
 """
 Minimal Memory System Example
 
-This demonstrates the simplest possible use of TOMLDiary for educational purposes.
+This demonstrates the simplest possible use of Diary for educational purposes.
 No external dependencies, no complex AI - just the core memory functionality.
 """
 
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from tomldiary import MemoryWriter, Diary, shutdown_all_background_tasks
+from tomldiary import Diary, MemoryWriter, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 from tomldiary.models import PreferenceItem
 
@@ -96,7 +96,7 @@ class SimpleAgent:
 
 async def simple_demo():
     """Educational demo showing the core memory system functionality."""
-    print("📚 TOMLDiary Educational Example")
+    print("📚 Diary Educational Example")
     print("=" * 40)
     print("This shows the simplest possible memory system usage.\n")
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from tomldiary import MemoryWriter, TOMLDiary, shutdown_all_background_tasks
+from tomldiary import MemoryWriter, Diary, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 from tomldiary.models import PreferenceItem
 
@@ -107,7 +107,7 @@ async def simple_demo():
 
     # 2. Create diary with simple schema
     print("2️⃣ Creating memory diary...")
-    diary = TOMLDiary(
+    diary = Diary(
         backend=backend,
         pref_table_cls=SimplePrefTable,
         agent=(agent, ["like", "dislike", "about"]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tomldiary"
-version = "0.0.1"
+version = "0.0.2"
 description = "A lightweight TOML-based memory system for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/tomldiary/__init__.py
+++ b/src/tomldiary/__init__.py
@@ -2,12 +2,13 @@
 tomldiary - A TOML-based memory system for tracking user preferences and conversations.
 """
 
-from .diary import TOMLDiary
+from .diary import Diary, TOMLDiary
 from .extractor_factory import build_extractor
 from .models import ConversationItem, MemoryDeps, MetaInfo, PreferenceItem
 from .writer import MemoryWriter, shutdown_all_background_tasks
 
 __all__ = [
+    "Diary",
     "TOMLDiary",
     "PreferenceItem",
     "ConversationItem",

--- a/src/tomldiary/backends/__init__.py
+++ b/src/tomldiary/backends/__init__.py
@@ -1,5 +1,5 @@
 """
-Backend implementations for TOMLDiary storage.
+Backend implementations for Diary storage.
 """
 
 from .local import LocalBackend

--- a/src/tomldiary/diary.py
+++ b/src/tomldiary/diary.py
@@ -8,7 +8,7 @@ from .models import _MODEL_VERSION, ConversationItem, MemoryDeps
 from .utils import extract_categories_from_schema
 
 
-class TOMLDiary:
+class Diary:
     def __init__(
         self, backend, pref_table_cls, agent=None, max_prefs_per_category=100, max_conversations=100
     ):
@@ -161,3 +161,7 @@ class TOMLDiary:
         return dict(
             sorted(conv_entries.items(), key=lambda kv: kv[1]["_created"], reverse=True)[:n]
         )
+
+
+# Backwards compatibility alias
+TOMLDiary = Diary

--- a/tests/test_diary.py
+++ b/tests/test_diary.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from tomldiary.backends.local import LocalBackend
-from tomldiary.diary import TOMLDiary
+from tomldiary import Diary
 from tomldiary.models import MemoryDeps
 
 from .test_user_pref_table import MyPrefTable
@@ -37,7 +37,7 @@ class MockAgent:
 
 
 class TestTOMLDiary:
-    """Test TOMLDiary functionality."""
+    """Test Diary functionality."""
 
     @pytest.fixture
     def temp_dir(self):
@@ -59,8 +59,8 @@ class TestTOMLDiary:
 
     @pytest.fixture
     def diary(self, backend, mock_agent):
-        """Create TOMLDiary with mock agent."""
-        return TOMLDiary(
+        """Create Diary with mock agent."""
+        return Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(mock_agent, ["like", "dislike", "allergy", "habit", "about"]),
@@ -158,7 +158,7 @@ class TestTOMLDiary:
     async def test_preference_limits(self, diary, backend):
         """Test preference limit enforcement."""
         # Create diary with very low preference limit
-        diary_low_limit = TOMLDiary(
+        diary_low_limit = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(MockAgent(), ["like", "dislike", "allergy", "habit", "about"]),

--- a/tests/test_diary.py
+++ b/tests/test_diary.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from tomldiary.backends.local import LocalBackend
 from tomldiary import Diary
+from tomldiary.backends.local import LocalBackend
 from tomldiary.models import MemoryDeps
 
 from .test_user_pref_table import MyPrefTable
@@ -36,7 +36,7 @@ class MockAgent:
             }
 
 
-class TestTOMLDiary:
+class TestDiary:
     """Test Diary functionality."""
 
     @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from tomldiary import MemoryWriter, TOMLDiary, shutdown_all_background_tasks
+from tomldiary import MemoryWriter, Diary, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 
 from .test_user_pref_table import MyPrefTable
@@ -76,7 +76,7 @@ class TestIntegration:
         """Create complete diary system."""
         backend = LocalBackend(temp_dir)
         agent = MockExtractionAgent()
-        diary = TOMLDiary(
+        diary = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(agent, ["like", "dislike", "allergy", "habit", "about"]),
@@ -192,7 +192,7 @@ class TestIntegration:
         agent = MockExtractionAgent()
 
         # Create diary with very low limits
-        diary = TOMLDiary(
+        diary = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(agent, ["like", "dislike", "allergy", "habit", "about"]),
@@ -230,7 +230,7 @@ class TestIntegration:
         await writer1.close()
 
         # Create new diary instance with same backend
-        diary2 = TOMLDiary(
+        diary2 = Diary(
             backend=diary1.backend,  # Same backend
             pref_table_cls=MyPrefTable,
             agent=(MockExtractionAgent(), ["like", "dislike", "allergy", "habit", "about"]),
@@ -331,7 +331,7 @@ class TestIntegration:
                 if self.call_count % 3 == 0:  # Fail every 3rd call
                     raise RuntimeError("Simulated agent failure")
 
-        diary = TOMLDiary(
+        diary = Diary(
             backend=backend,
             pref_table_cls=MyPrefTable,
             agent=(FlakyAgent(), ["like", "dislike", "allergy", "habit", "about"]),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from tomldiary import MemoryWriter, Diary, shutdown_all_background_tasks
+from tomldiary import Diary, MemoryWriter, shutdown_all_background_tasks
 from tomldiary.backends.local import LocalBackend
 
 from .test_user_pref_table import MyPrefTable


### PR DESCRIPTION
## Summary
- bump version to 0.0.2
- rename `TOMLDiary` class to `Diary` and export alias
- update docs, examples and tests to use `Diary`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688510a039f4832a85412733434b17e3