### PR TITLE
feat: add configurable extractor with prompt check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated cooking show example to use direct `diary.update_memory()` calls for reliable memory persistence
 
 
+## [0.0.4] - 2025-08-06
+
+### Added
+- `extractor_agent` with configurable retries and env-driven default model
+- `extractor_prompt_check` helper and example usage
+
+### Changed
+- Documentation and examples updated to reference `extractor_agent`
+
+
 
 ## [0.0.1] - 2025-07-20
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -47,7 +47,7 @@ class S3Backend:
         self.bucket = bucket
         self.prefix = prefix
         self.session = aioboto3.Session()
-    
+
     async def load(self, user_id: str, kind: str) -> Optional[str]:
         async with self.session.client('s3') as s3:
             key = f"{self.prefix}/{user_id}_{kind}.toml"
@@ -57,7 +57,7 @@ class S3Backend:
                 return content.decode('utf-8')
             except s3.exceptions.NoSuchKey:
                 return None
-    
+
     async def save(self, user_id: str, kind: str, content: str):
         async with self.session.client('s3') as s3:
             key = f"{self.prefix}/{user_id}_{kind}.toml"
@@ -79,18 +79,18 @@ class RedisBackend:
     def __init__(self, redis_url: str = "redis://localhost"):
         self.redis_url = redis_url
         self.redis = None
-    
+
     async def _get_redis(self):
         if not self.redis:
             self.redis = await aioredis.from_url(self.redis_url)
         return self.redis
-    
+
     async def load(self, user_id: str, kind: str) -> Optional[str]:
         redis = await self._get_redis()
         key = f"memory:{user_id}:{kind}"
         value = await redis.get(key)
         return value.decode('utf-8') if value else None
-    
+
     async def save(self, user_id: str, kind: str, content: str):
         redis = await self._get_redis()
         key = f"memory:{user_id}:{kind}"
@@ -103,10 +103,10 @@ You can provide your own extraction agent:
 
 ```python
 from pydantic_ai import Agent
-from tomldiary import build_extractor
+from tomldiary import extractor_agent
 
 # Start with the default agent
-agent, allowed_categories = build_extractor(MyPrefTable)
+agent, allowed_categories = extractor_agent(MyPrefTable)
 
 # Customize the agent
 agent = agent.with_system_prompt("""
@@ -149,7 +149,7 @@ async def batch_process(writer, conversations):
     for user_id, session_id, user_msg, bot_msg in conversations:
         task = writer.submit(user_id, session_id, user_msg, bot_msg)
         tasks.append(task)
-    
+
     # Submit all at once
     await asyncio.gather(*tasks)
 ```
@@ -177,20 +177,20 @@ Implement custom cleanup logic:
 async def cleanup_old_memories(diary, user_id, days=30):
     # Load conversations
     convs_data = await diary._load_convs(user_id)
-    
+
     # Filter old conversations
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     filtered = {}
-    
+
     for session_id, conv in convs_data.items():
         if session_id == "_meta":
             filtered[session_id] = conv
             continue
-            
+
         created = datetime.fromisoformat(conv.get("_created", ""))
         if created > cutoff:
             filtered[session_id] = conv
-    
+
     # Save filtered data
     await diary._save_convs(user_id, filtered)
 ```
@@ -207,10 +207,10 @@ class RobustMemoryWriter(MemoryWriter):
         except Exception as e:
             # Log error
             print(f"Failed to process memory: {e}")
-            
+
             # Send to dead letter queue
             await self.dead_letter_queue.put(item)
-            
+
             # Alert monitoring
             await self.alert_monitor(item, e)
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,7 +22,8 @@ class Diary:
 
 - `backend`: Storage backend instance (e.g., LocalBackend)
 - `pref_table_cls`: Pydantic model defining preference categories
-- `agent`: Optional custom extraction agent
+- `agent`: Optional custom extraction agent. If omitted, `extractor_agent()`
+  is used with the model name from `EXTRACTOR_MODEL` (default `gpt-5-mini`).
 - `max_prefs_per_category`: Maximum preferences per category (default: 100)
 - `max_conversations`: Maximum conversation history (default: 100)
 
@@ -178,5 +179,9 @@ Update the summary and keywords for the current conversation session.
 ### `shutdown_all_background_tasks(timeout: float = 10.0)`
 Shutdown all background tasks gracefully.
 
-### `build_extractor(pref_table_cls: Type[BaseModel]) -> Tuple[Agent, List[str]]`
-Build the default extraction agent for a preference table.
+### `extractor_agent(pref_table_cls: Type[BaseModel], model_name: str | None = None, prompt_template: str | Path | Prompt | None = None, fallback_retries: int = 3, fallback_on: Callable[[Exception], bool] | Sequence[type[Exception]] | None = None) -> Tuple[Agent, List[str]]`
+Build the default extraction agent for a preference table. Uses `EXTRACTOR_MODEL`
+or `gpt-5-mini` for the model name. `build_extractor()` is a legacy alias.
+
+### `extractor_prompt_check(prompt: str | Path | Prompt) -> None`
+Validate a custom extractor prompt and warn about missing placeholders.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ from pydantic import BaseModel
 from typing import Dict
 from tomldiary import (
     Diary,
-    MemoryWriter, 
+    MemoryWriter,
     PreferenceItem,
     shutdown_all_background_tasks
 )
@@ -45,15 +45,15 @@ class SimplePrefTable(BaseModel):
     dislike: Dict[str, PreferenceItem] = {}
 
 async def main():
-    # Step 2: Create the diary
+    # Step 2: Create the diary (uses extractor_agent by default)
     diary = Diary(
         backend=LocalBackend(Path("./my_memories")),
         pref_table_cls=SimplePrefTable
     )
-    
+
     # Step 3: Create the writer
     writer = MemoryWriter(diary)
-    
+
     # Step 4: Process some conversations, requires LLM call
     await writer.submit(
         user_id="user123",
@@ -61,15 +61,15 @@ async def main():
         user_msg="I love chocolate ice cream!",
         assistant_msg="I'll remember you love chocolate ice cream."
     )
-    
+
     # Wait a bit for processing
     await asyncio.sleep(1)
-    
+
     # Step 5: Read the memories
     prefs = await diary.preferences("user123")
     print("User preferences:")
     print(prefs)
-    
+
     # Step 6: Clean up
     await writer.close()
     await shutdown_all_background_tasks()

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,7 @@ This folder contains examples demonstrating the TOML Diary memory system:
 Educational demonstration of core memory functionality.
 
 **Perfect for learning:**
-- Self-contained with no external dependencies  
+- Self-contained with no external dependencies
 - Simple 3-category preference schema (like/dislike/about)
 - Clear step-by-step process explanation
 - Minimal conversations showing basic extraction
@@ -28,7 +28,7 @@ Educational demonstration of core memory functionality.
 
 **Features:**
 - Basic text-based preference extraction
-- Multi-user memory isolation 
+- Multi-user memory isolation
 - TOML file generation and structure
 - Conversation logging with turn counts
 
@@ -56,9 +56,19 @@ cd examples
 python example_cooking_show.py
 ```
 
+### 🛠️ Custom Extractor (`extractor_agent_example.py`)
+Demonstrates using `extractor_agent`, manual `Agent` setup, and `extractor_prompt_check`
+with explicit prompt paths.
+
+**Run:**
+```bash
+cd examples
+python extractor_agent_example.py
+```
+
 ## Preference Schema
 
-Both examples use the comprehensive `CulinaryPrefTable` with detailed AI instructions for each category:
+These examples use the comprehensive `CulinaryPrefTable` with detailed AI instructions for each category:
 
 ### Categories with AI Extraction Guidelines
 
@@ -99,7 +109,7 @@ Both examples use the comprehensive `CulinaryPrefTable` with detailed AI instruc
 - **Multi-user support**: Isolated memory per user
 - **Self-contained**: No external APIs or complex dependencies
 
-### 🍳 AI Cooking Show (Advanced)  
+### 🍳 AI Cooking Show (Advanced)
 - **AI Integration**: Pydantic-AI with OpenAI for natural conversations
 - **Dynamic agents**: Host and chef personalities with distinct behaviors
 - **Complex extraction**: Real-time preference extraction from organic dialogue
@@ -117,7 +127,7 @@ Both examples use the comprehensive `CulinaryPrefTable` with detailed AI instruc
 
 Each example creates:
 - Individual TOML files for each chef's preferences
-- Conversation logs with turn counts  
+- Conversation logs with turn counts
 - Formatted display of extracted memories
 - Sample TOML content for inspection
 

--- a/examples/example_cooking_show.py
+++ b/examples/example_cooking_show.py
@@ -55,19 +55,19 @@ async def add_chef_memory(ctx: RunContext[CookingShowContext]) -> str:
     """Add the chef's existing memory context to the system prompt."""
     # Use diary's built-in pretty printing methods
     memory_parts = []
-    
+
     # Get formatted preferences
     formatted_prefs = await ctx.deps.diary.pretty_preferences(ctx.deps.chef_name)
     if formatted_prefs != "No preferences found for user.":
         memory_parts.append("Your existing preferences:")
         memory_parts.append(formatted_prefs)
-    
+
     # Get formatted conversations
     formatted_convs = await ctx.deps.diary.pretty_conversations(ctx.deps.chef_name, limit=3)
     if formatted_convs != "No conversations found for user.":
         memory_parts.append("Recent conversation highlights:")
         memory_parts.append(formatted_convs)
-    
+
     return "\n\n".join(memory_parts) if memory_parts else ""
 
 
@@ -81,28 +81,28 @@ def add_chef_personality(ctx: RunContext[CookingShowContext]) -> str:
 
 async def chef_interview(chef_name: str, chef_personality: str, episodes: list[tuple[str, str]], diary: Diary):
     """Conduct an interview with a celebrity chef using AI agents"""
-    
+
     for episode, topic in episodes:
         print(f"\n📺 {chef_name} - Episode: {episode}")
         print("-" * 40)
-        
+
         # Create context with personality included
         context = CookingShowContext(chef_name, episode, diary, chef_personality)
-        
+
         # Host introduces the topic
         host_intro = await host_agent.run(
             f"Welcome chef! Today let's talk about {topic}. What are your thoughts?",
             deps=context
         )
         print(f"🎤 Host: {host_intro.output}")
-        
+
         # Chef responds (system prompt will dynamically include memory and personality)
         chef_response = await chef_agent.run(
             host_intro.output,
             deps=context
         )
         print(f"👨‍🍳 {chef_name}: {chef_response.output}")
-        
+
         # Update memory using direct diary.update_memory() call
         await diary.update_memory(
             user_id=chef_name,
@@ -110,7 +110,7 @@ async def chef_interview(chef_name: str, chef_personality: str, episodes: list[t
             user_msg=host_intro.output,
             assistant_msg=chef_response.output
         )
-        
+
         # Continue conversation with follow-up
         host_followup = await host_agent.run(
             f"That's fascinating! Can you tell me more about your preferences regarding {topic}?",
@@ -118,14 +118,14 @@ async def chef_interview(chef_name: str, chef_personality: str, episodes: list[t
             message_history=host_intro.new_messages()
         )
         print(f"🎤 Host: {host_followup.output}")
-        
+
         chef_detail = await chef_agent.run(
             host_followup.output,
             deps=context,
             message_history=chef_response.new_messages()
         )
         print(f"👨‍🍳 {chef_name}: {chef_detail.output}")
-        
+
         # Update memory for the follow-up exchange
         await diary.update_memory(
             user_id=chef_name,
@@ -139,18 +139,18 @@ async def cooking_show_demo():
     """Run the AI-powered cooking show memory demo."""
     print("🍳 Welcome to the AI Cooking Show Memory System!")
     print("=" * 50)
-    
+
     # Setup
     backend = LocalBackend(Path("memory_cooking_show"))
-    
-    # Create diary with build_extractor (proper approach)
+
+    # Create diary with extractor_agent (default behavior)
     diary = Diary(
         backend=backend,
         pref_table_cls=CulinaryPrefTable,
         max_prefs_per_category=10,
         max_conversations=5
     )
-    
+
     # Chef personalities and interview topics
     chefs = [
         ("chef_gordon", "A passionate British chef known for high standards and fiery temperament. Loves perfection.", [
@@ -166,24 +166,24 @@ async def cooking_show_demo():
             ("ingredient_focus", "working with fresh ingredients")
         ])
     ]
-    
+
     # Conduct interviews
     print("\n🎬 Starting celebrity chef interviews...\n")
-    
+
     for chef_name, personality, episodes in chefs:
         await chef_interview(chef_name, personality, episodes, diary)
         await asyncio.sleep(0.5)  # Brief pause between chefs
-    
+
     print("\n📚 Chef Memory Profiles:")
     print("=" * 50)
-    
+
     # Display the memories for each chef
     chefs = ["chef_gordon", "chef_julia", "chef_marco"]
-    
+
     for chef_name in chefs:
         print(f"\n👨‍🍳 {chef_name.upper().replace('_', ' ')}")
         print("-" * 30)
-        
+
         # Show preferences
         formatted_prefs = await diary.pretty_preferences(chef_name)
         if formatted_prefs != "No preferences found for user.":
@@ -191,7 +191,7 @@ async def cooking_show_demo():
             for line in formatted_prefs.split('\n'):
                 if line.strip():
                     print(f"  {line}")
-        
+
         # Show conversation summaries
         formatted_convs = await diary.pretty_conversations(chef_name, limit=3)
         if formatted_convs != "No conversations found for user.":
@@ -199,7 +199,7 @@ async def cooking_show_demo():
             for line in formatted_convs.split('\n'):
                 if line.strip():
                     print(f"  {line}")
-    
+
     # Show raw TOML for one chef
     print(f"\n📄 Sample TOML (chef_gordon preferences):")
     print("-" * 50)
@@ -208,7 +208,7 @@ async def cooking_show_demo():
         # Show first 800 characters
         preview = gordon_prefs[:800] + "..." if len(gordon_prefs) > 800 else gordon_prefs
         print(preview)
-    
+
     # Show conversation TOML
     print(f"\n📄 Sample TOML (chef_gordon conversations):")
     print("-" * 50)
@@ -217,7 +217,7 @@ async def cooking_show_demo():
         import tomli_w
         convs_preview = tomli_w.dumps(gordon_convs)[:600] + "..." if len(tomli_w.dumps(gordon_convs)) > 600 else tomli_w.dumps(gordon_convs)
         print(convs_preview)
-    
+
     print("\n✨ Cooking show memories saved successfully!")
     print(f"📁 Check the 'memory_cooking_show' directory for TOML files")
 

--- a/examples/extractor_agent_example.py
+++ b/examples/extractor_agent_example.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Demonstrate using extractor_agent and manual agent setup."""
+
+from pathlib import Path
+
+from pydantic_ai import Agent
+from textprompts import Prompt
+from tomldiary import Diary, extractor_agent, extractor_prompt_check
+from tomldiary.backends import LocalBackend
+
+from examples.culinary_prefs import CulinaryPrefTable
+
+
+def main() -> None:
+    prompt_path = Path(__file__).parent.parent / "src/tomldiary/prompts/extractor_prompt.txt"
+
+    # Check the prompt for required placeholders
+    extractor_prompt_check(prompt_path)
+
+    # Automatically build agent with fallback support
+    agent, allowed = extractor_agent(CulinaryPrefTable, prompt_template=prompt_path)
+    diary = Diary(LocalBackend(Path("memory_extractor")), CulinaryPrefTable, agent=(agent, allowed))
+
+    # Manual pydantic-ai Agent using textprompts directly
+    prompt_obj = Prompt.from_path(prompt_path, meta="allow")
+    manual = Agent("gpt-5-mini", system_prompt=prompt_obj.prompt)
+    manual_diary = Diary(
+        LocalBackend(Path("memory_manual")),
+        CulinaryPrefTable,
+        agent=(manual, allowed),
+    )
+
+    # Use diaries as needed... (omitted for brevity)
+    print("Extractor agent ready:", bool(diary))
+    print("Manual agent ready:", bool(manual_diary))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tomldiary"
-version = "0.0.3"
+version = "0.0.4"
 description = "A lightweight TOML-based memory system for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/tomldiary/__init__.py
+++ b/src/tomldiary/__init__.py
@@ -3,7 +3,7 @@ tomldiary - A TOML-based memory system for tracking user preferences and convers
 """
 
 from .diary import Diary, TOMLDiary
-from .extractor_factory import build_extractor
+from .extractor_factory import build_extractor, extractor_agent, extractor_prompt_check
 from .models import ConversationItem, MemoryDeps, MetaInfo, PreferenceItem
 from .pretty_print import (
     ConversationsPrinter,
@@ -21,6 +21,8 @@ __all__ = [
     "MemoryDeps",
     "MetaInfo",
     "build_extractor",
+    "extractor_agent",
+    "extractor_prompt_check",
     "MemoryWriter",
     "shutdown_all_background_tasks",
     "PreferencesPrinter",

--- a/src/tomldiary/extractor_factory.py
+++ b/src/tomldiary/extractor_factory.py
@@ -1,22 +1,55 @@
 # pragma: no cover
 import inspect
+import os
+import re
 import textwrap
 import tomllib
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
+import httpx
 import tomli_w
-from pydantic_ai import Agent, ModelRetry, RunContext, Tool
+from pydantic import ValidationError
+from pydantic_ai import Agent, ModelHTTPError, ModelRetry, RunContext, Tool
+from pydantic_ai.models.fallback import FallbackModel
 from textprompts import Prompt
 
 from . import tools
 from .models import MemoryDeps
 from .utils import extract_categories_from_schema
 
+REQUIRED_PLACEHOLDERS = {"categories_doc"}
 
-def build_extractor(
+
+def _warn_missing_placeholders(prompt_text: str, required: Sequence[str]) -> None:
+    """Check placeholders in the prompt and warn if required ones are missing."""
+
+    found = set(re.findall(r"{(.*?)}", prompt_text))
+    missing = set(required) - found
+    if missing:  # pragma: no cover - trivial warning
+        print(
+            "⚠️  Missing placeholder(s) in prompt: "
+            + ", ".join(sorted(missing))
+            + ". This may hurt extraction results."
+        )
+
+
+def extractor_prompt_check(prompt: str | Path | Prompt) -> None:
+    """Public helper to validate custom prompt placeholders."""
+
+    if isinstance(prompt, Prompt):
+        text = prompt.prompt
+    else:
+        text = Prompt.from_path(Path(prompt), meta="allow").prompt
+    _warn_missing_placeholders(text, REQUIRED_PLACEHOLDERS)
+
+
+def extractor_agent(
     pref_table_cls,
-    model_name="openai:gpt-4.1-mini",
-    prompt_template_path=None,
+    model_name: str | None = None,
+    prompt_template: str | Path | Prompt | None = None,
+    fallback_retries: int = 3,
+    fallback_on: Callable[[Exception], bool] | Sequence[type[Exception]] | None = None,
 ):  # pragma: no cover - CLI helper
     """Build an extraction agent for the given preference table class."""
 
@@ -24,14 +57,17 @@ def build_extractor(
     cats = extract_categories_from_schema(pref_table_cls)
     docs = textwrap.dedent(inspect.getdoc(pref_table_cls) or "")
 
-    # Use default prompt template path if not provided
-    if prompt_template_path is None:
-        prompt_template_path = Path(__file__).parent / "prompts" / "extractor_prompt.txt"
+    # Use default prompt template if not provided
+    if prompt_template is None:
+        prompt_template = Path(__file__).parent / "prompts" / "extractor_prompt.txt"
 
-    prompt_template = Prompt.from_path(prompt_template_path, meta="allow").prompt
-    system_prompt = prompt_template.format(
-        categories_doc=docs,
-    )
+    if isinstance(prompt_template, Prompt):
+        prompt_obj = prompt_template
+    else:
+        prompt_obj = Prompt.from_path(Path(prompt_template), meta="allow")
+
+    extractor_prompt_check(prompt_obj)
+    system_prompt = prompt_obj.prompt.format(categories_doc=docs)
 
     # 2. assemble tools with updated names
     tool_list = [
@@ -43,9 +79,34 @@ def build_extractor(
         Tool(tools.update_conversation_summary, takes_ctx=True),
     ]
 
-    # 3. create agent
+    # 3. build model with fallback retries
+    if fallback_on is None:
+        fallback_on = (ModelHTTPError, ValidationError, httpx.TimeoutException)
+
+    if (
+        isinstance(fallback_on, Sequence)
+        and not isinstance(fallback_on, str)
+        and not callable(fallback_on)
+    ):
+        fallback_on_param: Callable[[Exception], bool] | Sequence[type[Exception]] = tuple(
+            fallback_on
+        )
+    else:
+        fallback_on_param = fallback_on
+
+    model_name = model_name or os.getenv("EXTRACTOR_MODEL", "gpt-5-mini")
+    fallback_model = (
+        FallbackModel(
+            model_name,
+            *[model_name] * fallback_retries,
+            fallback_on=fallback_on_param,
+        )
+        if fallback_retries > 0
+        else model_name
+    )
+
     agent = Agent(
-        model_name,
+        fallback_model,
         deps_type=MemoryDeps,
         tools=tool_list,
         system_prompt=system_prompt,
@@ -67,3 +128,17 @@ def build_extractor(
         return output
 
     return agent, cats
+
+
+def build_extractor(
+    pref_table_cls,
+    model_name: str | None = None,
+    prompt_template_path: str | Path | Prompt | None = None,
+):  # pragma: no cover - legacy alias
+    """Backward compatible alias for :func:`extractor_agent`."""
+
+    return extractor_agent(
+        pref_table_cls,
+        model_name=model_name,
+        prompt_template=prompt_template_path,
+    )

--- a/tests/test_extractor_factory.py
+++ b/tests/test_extractor_factory.py
@@ -1,0 +1,59 @@
+import httpx
+from pydantic import BaseModel, ValidationError
+from pydantic_ai import ModelHTTPError
+from pydantic_ai.models.fallback import FallbackModel
+from textprompts import Prompt
+
+from src.tomldiary.extractor_factory import (
+    extractor_agent,
+    extractor_prompt_check,
+)
+from tests.test_user_pref_table import MyPrefTable
+
+
+def test_fallback_model_creation():
+    agent, _ = extractor_agent(MyPrefTable, model_name="test", fallback_retries=2)
+    assert isinstance(agent.model, FallbackModel)
+    assert len(agent.model.models) == 3
+    assert agent.model._fallback_on(ModelHTTPError(500, "test"))
+
+    class M(BaseModel):
+        a: int
+
+    try:
+        M(a="x")
+    except ValidationError as e:  # pragma: no cover - executed for side effect
+        assert agent.model._fallback_on(e)
+
+    assert agent.model._fallback_on(httpx.TimeoutException("boom"))
+
+
+def test_prompt_object_handled(tmp_path, capsys):
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("Test {categories_doc}")
+    prompt_obj = Prompt.from_path(prompt_path, meta="allow")
+    agent, _ = extractor_agent(MyPrefTable, model_name="test", prompt_template=prompt_obj)
+    assert "{categories_doc}" not in agent._system_prompts[0]
+    assert capsys.readouterr().out == ""
+
+
+def test_missing_placeholder_warning(tmp_path, capsys):
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("No placeholders here")
+    extractor_agent(MyPrefTable, model_name="test", prompt_template=prompt_path)
+    captured = capsys.readouterr()
+    assert "Missing placeholder" in captured.out
+
+
+def test_prompt_check_warns(tmp_path, capsys):
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("No placeholders here")
+    extractor_prompt_check(prompt_path)
+    assert "Missing placeholder" in capsys.readouterr().out
+
+
+def test_env_model_default(monkeypatch):
+    monkeypatch.setenv("EXTRACTOR_MODEL", "test")
+    agent, _ = extractor_agent(MyPrefTable, fallback_retries=1)
+    assert agent.model.models[0].model_name == "test"
+    monkeypatch.delenv("EXTRACTOR_MODEL", raising=False)


### PR DESCRIPTION
## Summary
- rename helper to `extractor_agent` and add `extractor_prompt_check`
- document and exemplify using `extractor_agent` with manual prompts
- default model from `EXTRACTOR_MODEL` env and bump version

## Testing
- `pre-commit run --files src/tomldiary/extractor_factory.py src/tomldiary/__init__.py tests/test_extractor_factory.py examples/example_cooking_show.py examples/extractor_agent_example.py examples/README.md docs/advanced-usage.md docs/api-reference.md docs/getting-started.md pyproject.toml CHANGELOG.md`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_689715596c94832a8e229165962a027f