### PR TITLE
Add Datetime awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2025-01-02
+
+### Updated
+- Time awareness for extractor agent: current time (rounded to nearest 15 minutes) is now provided to the agent via `{current_time}` placeholder
+- Updated extractor prompt to version 3.0 with time context
+
 ## [0.0.4] - 2025-08-10
 
 ### Updated

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ format:
 
 # Run tests
 test:
-	pytest
+	uv run -m pytest --cov=tomldiary --cov-report=term-missing
 
 # CI target - run lint and test
 ci: lint test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tomldiary"
-version = "0.0.4"
+version = "0.0.5"
 description = "A lightweight TOML-based memory system for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/tomldiary/extractor_factory.py
+++ b/src/tomldiary/extractor_factory.py
@@ -5,6 +5,7 @@ import re
 import textwrap
 import tomllib
 from collections.abc import Callable, Sequence
+from datetime import datetime
 from pathlib import Path
 
 import httpx
@@ -17,7 +18,7 @@ from textprompts import Prompt
 from . import tools
 from .models import MemoryDeps
 
-REQUIRED_PLACEHOLDERS = {"categories_doc"}
+REQUIRED_PLACEHOLDERS = {"categories_doc", "current_time"}
 
 
 def _warn_missing_placeholders(prompt_text: str, required: Sequence[str]) -> None:
@@ -65,7 +66,14 @@ def extractor_agent(
         prompt_obj = Prompt.from_path(Path(prompt_template), meta="allow")
 
     extractor_prompt_check(prompt_obj)
-    system_prompt = prompt_obj.prompt.format(categories_doc=docs)
+
+    # Get current time rounded to nearest 15 minutes (to not break prompt caching)
+    now = datetime.now()
+    minutes = (now.minute // 15) * 15
+    rounded_time = now.replace(minute=minutes, second=0, microsecond=0)
+    current_time = rounded_time.strftime("%Y-%m-%d %H:%M")
+
+    system_prompt = prompt_obj.prompt.format(categories_doc=docs, current_time=current_time)
 
     # 2. assemble tools with updated names
     tool_list = [

--- a/src/tomldiary/prompts/extractor_prompt.txt
+++ b/src/tomldiary/prompts/extractor_prompt.txt
@@ -1,9 +1,11 @@
 ---
 title = "Extractor Agent for updating TomlDiary"
-version = "2.0"
+version = "3.0"
 description = "Main system prompt for TomlDiary"
 ---
 Your task is to extract/update user preferences and update conversation summaries across many conversations. You'll be provided with current diary state and the latest unsafe user/assistant messages.
+
+Current time: {current_time}
 
 Preference extraction occurs across many conversations and we evolve them based on new conversation only when we have high quality preferences that we want to store. Most messages will not have any preferences to store.
 

--- a/tests/test_extractor_factory.py
+++ b/tests/test_extractor_factory.py
@@ -30,10 +30,11 @@ def test_fallback_model_creation():
 
 def test_prompt_object_handled(tmp_path, capsys):
     prompt_path = tmp_path / "prompt.txt"
-    prompt_path.write_text("Test {categories_doc}")
+    prompt_path.write_text("Test {categories_doc} {current_time}")
     prompt_obj = Prompt.from_path(prompt_path, meta="allow")
     agent = extractor_agent(MyPrefTable, model_name="test", prompt_template=prompt_obj)
     assert "{categories_doc}" not in agent._system_prompts[0]
+    assert "{current_time}" not in agent._system_prompts[0]
     assert capsys.readouterr().out == ""
 
 
@@ -43,13 +44,18 @@ def test_missing_placeholder_warning(tmp_path, capsys):
     extractor_agent(MyPrefTable, model_name="test", prompt_template=prompt_path)
     captured = capsys.readouterr()
     assert "Missing placeholder" in captured.out
+    assert "categories_doc" in captured.out
+    assert "current_time" in captured.out
 
 
 def test_prompt_check_warns(tmp_path, capsys):
     prompt_path = tmp_path / "prompt.txt"
     prompt_path.write_text("No placeholders here")
     extractor_prompt_check(prompt_path)
-    assert "Missing placeholder" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Missing placeholder" in output
+    assert "categories_doc" in output
+    assert "current_time" in output
 
 
 def test_env_model_default(monkeypatch):
@@ -57,3 +63,17 @@ def test_env_model_default(monkeypatch):
     agent = extractor_agent(MyPrefTable, fallback_retries=1)
     assert agent.model.models[0].model_name == "test"
     monkeypatch.delenv("EXTRACTOR_MODEL", raising=False)
+
+
+def test_current_time_in_prompt():
+    agent = extractor_agent(MyPrefTable, model_name="test")
+    system_prompt = agent._system_prompts[0]
+    # Check that current_time placeholder was replaced with a timestamp
+    assert "{current_time}" not in system_prompt
+    # Check that a date-time pattern exists in the prompt
+    import re
+    match = re.search(r"\d{4}-\d{2}-\d{2} \d{2}:(\d{2})", system_prompt)
+    assert match is not None
+    # Check that minutes are rounded to 15-minute intervals
+    minutes = int(match.group(1))
+    assert minutes in [0, 15, 30, 45]

--- a/tests/test_extractor_factory.py
+++ b/tests/test_extractor_factory.py
@@ -58,6 +58,14 @@ def test_prompt_check_warns(tmp_path, capsys):
     assert "current_time" in output
 
 
+def test_prompt_check_no_warning_when_valid(tmp_path, capsys):
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("Valid prompt with {categories_doc} and {current_time}")
+    extractor_prompt_check(prompt_path)
+    output = capsys.readouterr().out
+    assert output == ""  # No warning should be printed
+
+
 def test_env_model_default(monkeypatch):
     monkeypatch.setenv("EXTRACTOR_MODEL", "test")
     agent = extractor_agent(MyPrefTable, fallback_retries=1)
@@ -72,6 +80,7 @@ def test_current_time_in_prompt():
     assert "{current_time}" not in system_prompt
     # Check that a date-time pattern exists in the prompt
     import re
+
     match = re.search(r"\d{4}-\d{2}-\d{2} \d{2}:(\d{2})", system_prompt)
     assert match is not None
     # Check that minutes are rounded to 15-minute intervals


### PR DESCRIPTION
### Updated
- Time awareness for extractor agent: current time (rounded to nearest 15 minutes) is now provided to the agent via `{current_time}` placeholder
- Updated extractor prompt to version 3.0 with time context
